### PR TITLE
Use the concept of Subject for properties and features

### DIFF
--- a/src/client/app_configuration_http.rs
+++ b/src/client/app_configuration_http.rs
@@ -200,7 +200,7 @@ mod tests {
 
         // We evaluated the property 3 times (for two different configurations)
         {
-            let mut metering_data = metering_recv.recv().unwrap();
+            let metering_data = metering_recv.recv().unwrap();
             // The value for the `collection_id` and `environment_id` comes from the `ConfigurationId`
             // object that was provided to the `start_metering` function. It doesn't match
             // the `ConfigurationId` that was used to get the `Configuration` object. This
@@ -211,9 +211,7 @@ mod tests {
 
             // We expect 3 evaluations to be covered in metering.
             // Do not care about the way they are sorted.
-            let total_counts : u32 = metering_data
-                .usages
-                .iter().map(|usage| usage.count).sum();
+            let total_counts: u32 = metering_data.usages.iter().map(|usage| usage.count).sum();
             assert_eq!(total_counts, 3);
         }
     }
@@ -265,7 +263,7 @@ mod tests {
 
         // We evaluated the property 3 times (for two different configurations)
         {
-            let mut metering_data = metering_recv.recv().unwrap();
+            let metering_data = metering_recv.recv().unwrap();
             // The value for the `collection_id` and `environment_id` comes from the `ConfigurationId`
             // object that was provided to the `start_metering` function. It doesn't match
             // the `ConfigurationId` that was used to get the `Configuration` object. This
@@ -276,9 +274,7 @@ mod tests {
 
             // We expect 3 evaluations to be covered in metering.
             // Do not care about the way they are sorted.
-            let total_counts : u32 = metering_data
-                .usages
-                .iter().map(|usage| usage.count).sum();
+            let total_counts: u32 = metering_data.usages.iter().map(|usage| usage.count).sum();
             assert_eq!(total_counts, 3);
         }
     }

--- a/src/client/configuration.rs
+++ b/src/client/configuration.rs
@@ -184,6 +184,7 @@ impl ConfigurationProvider for Configuration {
             value,
             segment_rules.clone(),
             &property.name,
+            &property.property_id,
             None,
         ))
     }

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -17,6 +17,8 @@ mod errors;
 pub(crate) mod metering;
 
 pub(crate) use client::MeteringClient;
-pub(crate) use metering::{start_metering, MeteringRecorder, MeteringRecorderSender};
+pub(crate) use metering::{
+    start_metering, MeteringRecorder, MeteringRecorderSender, MeteringSubject,
+};
 
 pub type MeteringResult<T> = std::result::Result<T, errors::MeteringError>;


### PR DESCRIPTION
 * Add `property_id` to `PropertySnapshot`
 * Use `property_id` for metering
 * Use `Segment::segment_id` for metering
 * A new `MeteringSubject` trait (implemented for `PropertySnapshot` and `FeatureSnapshot`) so we can implement the logic inside the `metering` module